### PR TITLE
Updating tasks.json to link raylib library to fix undefined references

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,10 @@
                 "-g",
                 "${file}",
                 "-I",
-                "C:\\msys64\\mingw64\\include",
+                "C:/msys64/mingw64/include",
+                "-L",
+                "C:/msys64/mingw64/lib",
+                "-lraylib",
                 "-o",
                 "${fileDirname}\\${fileBasenameNoExtension}.exe"
             ],


### PR DESCRIPTION
We included C:\msys64\mingw64\include for raylib.h but we did not actually link the library. Included compiler arguments in tasks.json to link raylib libraries from C:\msys64\mingw64\lib